### PR TITLE
Ability to compute the nodule tri-dimensional measure and report bounds

### DIFF
--- a/src/LungNoduleSegmenter/CMakeLists.txt
+++ b/src/LungNoduleSegmenter/CMakeLists.txt
@@ -22,3 +22,26 @@ add_executable( LungNoduleSegmentation
 	../common/itkVTKViewImageAndSegmentation.h)
 target_link_libraries( LungNoduleSegmentation ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
+include(CTest)
+if (BUILD_TESTING)
+
+  # Test 1
+  file(MAKE_DIRECTORY ${LungNoduleSegmentater_BINARY_DIR}/NoduleSegmentationTest1)
+  file(MAKE_DIRECTORY ${LungNoduleSegmentater_BINARY_DIR}/NoduleSegmentationTest1/nodule_image)
+  add_test( NAME NoduleSegmentationTest1 COMMAND LungNoduleSegmentation
+    --InputDICOMDir ${LungNoduleSegmentater_SOURCE_DIR}/../../data/E00140/ --Seeds 3 -62 66 -91.5
+    --MaximumRadius 12.0 --Visualize 1 --Outline 1 --Screenshot nodule_image --Supersample 1
+    --SupersampledIsotropicSpacing .2 --WriteFeatureImages 1 --OutputMesh E00140.N1.vtp
+    WORKING_DIRECTORY ${LungNoduleSegmentater_BINARY_DIR}/NoduleSegmentationTest1 )
+
+  # Test 2
+  file(MAKE_DIRECTORY ${LungNoduleSegmentater_BINARY_DIR}/NoduleSegmentationTest2)
+  file(MAKE_DIRECTORY ${LungNoduleSegmentater_BINARY_DIR}/NoduleSegmentationTest2/nodule_image)
+  add_test( NAME NoduleSegmentationTest2 COMMAND LungNoduleSegmentation
+    --InputDICOMDir ${LungNoduleSegmentater_SOURCE_DIR}/../../data/E00140/ --Seeds 3 -46.8 -56.3 -91.4
+    --MaximumRadius 12.0 --Visualize 1 --Outline 1 --Screenshot nodule_image --Supersample 1
+    --SupersampledIsotropicSpacing .2 --WriteFeatureImages 1 --OutputMesh E00140.N2.vtp
+    WORKING_DIRECTORY ${LungNoduleSegmentater_BINARY_DIR}/NoduleSegmentationTest2 )
+
+endif()
+

--- a/src/LungNoduleSegmenter/LungNoduleSegmentation.cpp
+++ b/src/LungNoduleSegmenter/LungNoduleSegmentation.cpp
@@ -338,7 +338,25 @@ int main( int argc, char * argv[] )
 		view->SetSegmentationRenderMode(args.GetOptionWasSet("Outline") ?
 			itk::VTKViewImageAndSegmentation::SegmentationRenderMode::Outline :
 			itk::VTKViewImageAndSegmentation::SegmentationRenderMode::Surface);
-		std::cout << "Computed Volume = " << std::setprecision(8) << (view->GetVolume()) << " mm^3" << std::endl;
+		std::cout << "Volume = " << std::fixed << std::setprecision(2) << (view->GetVolume()) << " mm^3" << std::endl;
+
+		std::cout << "TriDimensional = "
+              << view->Sizer()->GetRECISTLength()
+              << " x "
+              << view->Sizer()->GetRECISTPerpLength()
+              << " x "
+              << view->Sizer()->GetRECISTZLength()
+              << " mm" << std::endl;
+
+    std::cout << "Nodule span along the X,Y,Z axes are " <<
+      (view->Sizer()->GetBBox()->GetMaximum() - view->Sizer()->GetBBox()->GetMinimum()) << " mm." << std::endl;
+
+    std::cout << "  RECIST measure endpoints are " << view->Sizer()->GetRECISTEndPoint1() << " to " << view->Sizer()->GetRECISTEndPoint2() << std::endl;
+    std::cout << "  RECIST Perp measure endpoints are " << view->Sizer()->GetRECISTPerpEndPoint1() << " to " << view->Sizer()->GetRECISTPerpEndPoint2() << std::endl;
+    std::cout << "  RECIST Z measure endpoints are " << view->Sizer()->GetRECISTZEndPoint1() << " to " << view->Sizer()->GetRECISTZEndPoint2() << std::endl;
+    std::cout << "  Nodule bounds along the X,Y,Z axes are from " << (view->Sizer()->GetBBox()->GetMinimum())
+      << " to " << (view->Sizer()->GetBBox()->GetMaximum()) << " mm." << std::endl;
+
 		if (args.GetOptionWasSet("OutputMesh"))
 			view->WriteSegmentationAsSurface(args.GetValueAsString("OutputMesh").c_str());
 

--- a/src/common/itkTriDimensionalMeasurementCalculator.h
+++ b/src/common/itkTriDimensionalMeasurementCalculator.h
@@ -1,0 +1,81 @@
+/*=========================================================================
+
+ Nodule Tri-dimensional mesure
+
+=========================================================================*/
+#pragma once
+
+#include "itkImage.h"
+#include "vtkPolyData.h"
+#include "itkBoundingBox.h"
+
+namespace itk
+{
+
+template< class TImage = itk::Image< short, 3 > >
+class TriDimensionalMeasurementCalculator : public itk::Object
+{
+public:
+  /** Standard Self typedef */
+  typedef TriDimensionalMeasurementCalculator Self;
+  typedef itk::Object                         Superclass;
+  typedef itk::SmartPointer<Self>             Pointer;
+  typedef itk::SmartPointer<const Self>       ConstPointer;
+  itkNewMacro(Self);
+  itkTypeMacro(TriDimensionalMeasurementCalculator, itk::Object);
+
+  typedef TImage ImageType;
+  typedef typename TImage::SizeType SizeType;
+  typedef typename TImage::IndexType IndexType;
+  typedef typename TImage::PointType PointType;
+  typedef typename TImage::SpacingType SpacingType;
+  typedef typename TImage::RegionType RegionType;
+
+  itkStaticConstMacro(ImageDimension, unsigned int, TImage::ImageDimension );
+
+  // Update prior to calling the 3 methods below
+  void Update();
+
+  // Get measures
+  itkGetMacro( RECISTEndPoint1, PointType );
+  itkGetMacro( RECISTEndPoint2, PointType );
+  itkGetMacro( RECISTLength, double );
+
+  itkGetMacro( RECISTPerpEndPoint1, PointType );
+  itkGetMacro( RECISTPerpEndPoint2, PointType );
+  itkGetMacro( RECISTPerpLength, double );
+
+  itkGetMacro( RECISTZEndPoint1, PointType );
+  itkGetMacro( RECISTZEndPoint2, PointType );
+  itkGetMacro( RECISTZLength, double );
+
+  itkGetObjectMacro( BBox, BoundingBox<> );
+
+  // must be set
+  void SetSurface( vtkPolyData *pd ) { m_Surface = pd; }
+  void SetImage( TImage *i ) { m_Image = i; }
+
+protected:
+  TriDimensionalMeasurementCalculator() : m_Image(NULL) {}
+  ~TriDimensionalMeasurementCalculator() {}
+
+  double 		m_RECISTLength;
+  double 		m_RECISTPerpLength;
+  double 		m_RECISTZLength;
+  PointType m_RECISTEndPoint1, m_RECISTEndPoint2;
+  PointType m_RECISTPerpEndPoint1, m_RECISTPerpEndPoint2;
+  PointType m_RECISTZEndPoint1, m_RECISTZEndPoint2;
+  PointType m_RECISTIntersection;
+  TImage *m_Image;
+  vtkPolyData *m_Surface;
+
+  BoundingBox<>::Pointer m_BBox;
+
+private:
+  TriDimensionalMeasurementCalculator(const TriDimensionalMeasurementCalculator&);  // Not implemented.
+  void operator=(const TriDimensionalMeasurementCalculator&);  // Not implemented.
+};
+
+}
+
+#include "itkTriDimensionalMeasurementCalculator.hxx"

--- a/src/common/itkTriDimensionalMeasurementCalculator.hxx
+++ b/src/common/itkTriDimensionalMeasurementCalculator.hxx
@@ -1,0 +1,288 @@
+/*=========================================================================
+
+Copyright (c) 2014 itkumetra, LLC
+
+=========================================================================*/
+
+#pragma once
+
+#include "itkTriDimensionalMeasurementCalculator.h"
+#include "vtkCutter.h"
+#include "vtkSmartPointer.h"
+#include "vtkDoubleArray.h"
+#include "vtkPointData.h"
+#include "vtkPlane.h"
+#include "vtkLine.h"
+#include "vtkCellLocator.h"
+#include "vtkCell.h"
+#include "vtkMath.h"
+
+namespace itk
+{
+
+template<class TImage>
+void
+TriDimensionalMeasurementCalculator<TImage>
+::Update()
+{
+  double bnds[6], ptOnPlane[3];
+  PointType origin = m_Image->GetOrigin();
+  SpacingType spacing = m_Image->GetSpacing();
+  RegionType region = m_Image->GetBufferedRegion();
+
+  double cutPolyBounds[6];
+  double xdistance, ydistance, zdistance, xtmp, ytmp, ztmp;
+  double recist, zrecist, p1[3], p2[3];
+  double displacement, displacement_pct;
+
+  typename RegionType::SizeType size = region.GetSize();
+  typename RegionType::IndexType index = region.GetIndex();
+  int indexStartZ = index[2], indexEndZ = index[2] + size[2] - 1;;
+  int indexStartX = index[0], indexEndX = index[0] + size[0] - 1;;
+
+  const int nSurfacePoints = m_Surface->GetNumberOfPoints();
+
+  /********************************************/
+  /*                                          */
+  /* Measure RECIST and ortho diameters on    */
+  /* the X-Y plane.                           */
+  /*                                          */
+  /********************************************/
+  m_Surface->GetBounds(bnds);
+  vtkSmartPointer< vtkCutter > cutter = vtkSmartPointer< vtkCutter >::New();
+  cutter->SetInputData(m_Surface);
+
+  vtkSmartPointer< vtkPlane > plane = vtkSmartPointer< vtkPlane >::New();
+  cutter->SetCutFunction(plane);
+
+  plane->SetNormal(0,0,1.0); // XY plane
+
+  ptOnPlane[0] = bnds[0];
+  ptOnPlane[1] = bnds[2];
+
+  recist = 0;
+  xdistance = 0;
+  ydistance = 0;
+
+  vtkSmartPointer< vtkPolyData > recistContour = vtkSmartPointer< vtkPolyData >::New();
+  for (int zIdx = indexStartZ; zIdx <= indexEndZ; ++zIdx)
+  {
+    const double z = (double)zIdx * spacing[2] + origin[2];
+    if (z < bnds[4] || z > bnds[5])
+    {
+      continue;
+    }
+
+    ptOnPlane[2] = z;
+    plane->SetOrigin(ptOnPlane);
+    cutter->Update();
+
+    vtkPolyData *cutPoly = cutter->GetOutput();
+    vtkPoints *cutPoints = cutPoly->GetPoints();
+    const int nPoints = cutPoly->GetNumberOfPoints();
+    cutPoly->GetBounds(cutPolyBounds);
+
+    // This slice cannot have a RECIST larger than what's already running high
+    const double maxPossible =
+     (cutPolyBounds[0] - cutPolyBounds[1])*
+     (cutPolyBounds[0] - cutPolyBounds[1]) +
+     (cutPolyBounds[2] - cutPolyBounds[3])*
+     (cutPolyBounds[2] - cutPolyBounds[3]);
+    if (maxPossible < recist)
+    {
+      continue;
+    }
+
+    bool biggestContourSoFar = false;
+    for (int i = 0; i < (nPoints-1); i++)	// Why nPoints -1 ?
+    {
+      cutPoints->GetPoint(i, p1);
+
+      for (int j = i; j < nPoints; j++)
+      {
+        cutPoints->GetPoint(j, p2);
+
+        // Compute distance between two 2D points for RECIST comparison
+        const double d = vtkMath::Distance2BetweenPoints(p1,p2);
+
+        if (d > recist)
+        {
+          recist = d;
+          this->m_RECISTEndPoint1[0] = p1[0];
+          this->m_RECISTEndPoint1[1] = p1[1];
+          this->m_RECISTEndPoint1[2] = p1[2];
+          this->m_RECISTEndPoint2[0] = p2[0];
+          this->m_RECISTEndPoint2[1] = p2[1];
+          this->m_RECISTEndPoint2[2] = p2[2];
+          this->m_RECISTLength = sqrt(recist);
+          biggestContourSoFar = true;
+        }
+
+      }
+    }
+
+    if (biggestContourSoFar)
+    {
+      recistContour->DeepCopy(cutPoly);
+    }
+  }
+
+  // At this point RECIST endpoints and RECIST length have been calculated
+  // The axial cut corresponding to the RECIST length - largest contour has also been computed.
+  // Now find the largest dia perpendicular to the recist line
+
+  vtkPoints *pts = recistContour->GetPoints();
+  const unsigned int nPts = pts->GetNumberOfPoints();
+
+  // define a plane normal to the recist length and a cutter to cut the RECIST contour with it
+  double normal[3] = { m_RECISTEndPoint1[0] - m_RECISTEndPoint2[0],
+                       m_RECISTEndPoint1[1] - m_RECISTEndPoint2[1],
+                       m_RECISTEndPoint1[2] - m_RECISTEndPoint2[2] };
+  vtkMath::Normalize(normal);
+  plane->SetNormal(normal);
+
+  cutter->SetInputData(recistContour);
+  cutter->SetCutFunction(plane);
+
+  // cut with every point on this contour keeping it perpendicular to the RECIST line.
+  // this will give us a line perpendicular to the RECIST on the same axial slice as the RECIST measure
+
+  double recistPerp = 0;
+
+  for (unsigned int i = 0; i < nPts; ++i)
+  {
+    plane->SetOrigin(pts->GetPoint(i));
+    plane->Modified();
+    cutter->Update();
+
+    if (vtkPoints *cutPts = cutter->GetOutput()->GetPoints())
+    {
+      const unsigned int nCutpts = cutPts->GetNumberOfPoints();
+      if (nCutpts >= 2)
+      {
+        for (unsigned int j = 0; j < nCutpts-1; ++j)
+        {
+          cutPts->GetPoint(j, p1);
+          for (unsigned int k = 1; k < nCutpts; ++k)
+          {
+            cutPts->GetPoint(k, p2);
+
+            // Compute distance between two 2D points for RECIST comparison
+            const double d = vtkMath::Distance2BetweenPoints(p1,p2);
+
+            if (d > recistPerp)
+            {
+              recistPerp = d;
+              this->m_RECISTPerpEndPoint1[0] = p1[0];
+              this->m_RECISTPerpEndPoint1[1] = p1[1];
+              this->m_RECISTPerpEndPoint1[2] = p1[2];
+              this->m_RECISTPerpEndPoint2[0] = p2[0];
+              this->m_RECISTPerpEndPoint2[1] = p2[1];
+              this->m_RECISTPerpEndPoint2[2] = p2[2];
+              this->m_RECISTPerpLength = sqrt(recistPerp);
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  // Now find the point of intersetion of the in-plane bi-dimensional measure.
+  vtkSmartPointer< vtkLine > line = vtkSmartPointer< vtkLine >::New();
+  vtkPoints* linePoints = line->GetPoints();
+  linePoints->SetNumberOfPoints(2);
+  linePoints->SetPoint( 0, m_RECISTEndPoint1.GetDataPointer() );
+  linePoints->SetPoint( 1, m_RECISTEndPoint2.GetDataPointer() );
+  line->GetPointIds()->SetId(0,0);
+  line->GetPointIds()->SetId(1,1);
+
+  // Intersect the RECIST and its perpendicular line.
+  double t, x[3], pcoords[3];
+  int subId;
+  int intersects = line->IntersectWithLine( m_RECISTPerpEndPoint1.GetDataPointer(),
+    m_RECISTPerpEndPoint2.GetDataPointer(), 0.001, t, x, pcoords, subId );
+
+  // The point of intersetion of the in-plane bi-dimensional measure.
+  m_RECISTIntersection[0] = x[0];
+  m_RECISTIntersection[1] = x[1];
+  m_RECISTIntersection[2] = x[2];
+
+  // std::cout << "RECIST measure endpoints are " << m_RECISTEndPoint1 << " to " << m_RECISTEndPoint2 << std::endl;
+  // std::cout << "RECIST Perp measure endpoints are " << m_RECISTPerpEndPoint1 << " to " << m_RECISTPerpEndPoint2 << std::endl;
+  // if (intersects)
+  //   std::cout << "BiDimensional measure intersects at " << m_RECISTIntersection << std::endl;
+  // else
+  //   std::cout << "BiDimensional measure does not intersect" << std::endl;
+
+  // Intersect the mesh along the 3D line
+  vtkSmartPointer< vtkCellLocator > cellLocator = vtkSmartPointer< vtkCellLocator >::New();
+  cellLocator->SetDataSet(m_Surface);
+  cellLocator->BuildLocator();
+
+  // A line through the RECIST intersection point along Z
+  memcpy(p1, m_RECISTIntersection.GetDataPointer(), 3 * sizeof(double));
+  memcpy(p2, m_RECISTIntersection.GetDataPointer(), 3 * sizeof(double));
+  p1[2] -= 100;
+  p2[2] += 100;
+
+  // find intersection along the above Z line
+  vtkSmartPointer<vtkIdList> cellIds = vtkSmartPointer<vtkIdList>::New();
+  cellLocator->FindCellsAlongLine(p1, p2, 0.0001, cellIds);
+
+  m_RECISTZLength = 0;
+  std::vector< PointType > intersectionPts;
+
+  //std::cout << "There are " << cellIds->GetNumberOfIds() << " intersections along Z" << std::endl;
+  for (vtkIdType q = 0; q < cellIds->GetNumberOfIds(); q++)
+  {
+
+    // Retrieve the cell that was intersected
+    double tmpFactor, tmpPoint[3];
+    vtkIdType cellId = cellIds->GetId(q);
+    vtkCell *cell = m_Surface->GetCell(cellId);
+
+    // Verify again by intersecting the specific cell that it really intersected.
+    // Also get the intersection point x.
+    if (cell->IntersectWithLine(p1, p2, 0.0001, t, x, pcoords, subId))
+    {
+      PointType intersectionPt;
+      for (int a = 0; a < 3; ++a)
+        intersectionPt[a] = x[a];
+      intersectionPts.push_back(intersectionPt);
+    }
+  }
+
+  // intersectionPts contains the intersetions of the segmentation surface with
+  // the line along the Z axis that passes through the in-plane bi-dimensional measure's intersection
+  if (intersectionPts.size() >= 2)
+  {
+    // find the farthest 2 intersections.
+    for (unsigned int q = 0; q < intersectionPts.size()-1; ++q)
+    {
+      for (unsigned int r = 1; r < intersectionPts.size(); ++r)
+      {
+        const double dist = (intersectionPts[q] - intersectionPts[r]).GetNorm();
+        if (m_RECISTZLength < dist)
+        {
+          m_RECISTZLength = dist;
+          m_RECISTZEndPoint1 = intersectionPts[q];
+          m_RECISTZEndPoint2 = intersectionPts[r];
+        }
+      }
+    }
+  }
+
+  PointType pmin, pmax;
+  for (int i = 0; i < 3; ++i)
+  {
+    pmin[i] = m_Surface->GetBounds()[2*i];
+    pmax[i] = m_Surface->GetBounds()[2*i+1];
+  }
+
+  m_BBox = BoundingBox<>::New();
+  m_BBox->SetMinimum(pmin);
+  m_BBox->SetMaximum(pmax);
+}
+
+} // end namespace itk

--- a/src/common/itkVTKViewImageAndSegmentation.cxx
+++ b/src/common/itkVTKViewImageAndSegmentation.cxx
@@ -72,6 +72,7 @@ namespace itk
 		m_Image = nullptr;
 		m_Mask = nullptr;
 		m_SegmentationRenderMode = VTKViewImageAndSegmentation::SegmentationRenderMode::Surface;
+    m_NoduleLengths = NoduleSizerType::New();
 	}
 
 	VTKViewImageAndSegmentation::~VTKViewImageAndSegmentation()
@@ -98,6 +99,8 @@ namespace itk
 		m_SurfaceProperties->SetInputData(m_Surface);
 		m_SurfaceProperties->Update();
 		m_Volume = m_SurfaceProperties->GetVolume();
+
+    ComputeNoduleLengths();
 	}
 
 	void VTKViewImageAndSegmentation::SetSegmentationSurfaceFromBinaryMask(
@@ -124,7 +127,16 @@ namespace itk
 		mc->Update();
 		m_Surface = vtkSmartPointer< vtkPolyData >::New();
 		m_Surface->DeepCopy(mc->GetOutput());
+
+    ComputeNoduleLengths();
 	}
+
+	void VTKViewImageAndSegmentation::ComputeNoduleLengths()
+	{
+		m_NoduleLengths->SetSurface(m_Surface);
+    m_NoduleLengths->SetImage(m_Image);
+    m_NoduleLengths->Update();
+  }
 
 	void VTKViewImageAndSegmentation::SetSegmentationSurface(vtkPolyData *pd)
 	{
@@ -134,6 +146,8 @@ namespace itk
 		m_SurfaceProperties->SetInputData(m_Surface);
 		m_SurfaceProperties->Update();
 		m_Volume = m_SurfaceProperties->GetVolume();
+
+    ComputeNoduleLengths();
 	}
 
 	int VTKViewImageAndSegmentation::View()
@@ -205,7 +219,7 @@ namespace itk
 
 		VTK_CREATE(vtkProperty, noduleProperty);
 
-		// Changed the color of the rendered nodule to be red 
+		// Changed the color of the rendered nodule to be red
 		// and with much less specular highlights.
 		noduleProperty->SetAmbient(0.3);
 		noduleProperty->SetDiffuse(0.6);
@@ -296,7 +310,7 @@ namespace itk
 	}
 
 	void VTKViewImageAndSegmentation::WriteSegmentationAsSurface( const std::string &fn )
-	{		
+	{
 		vtkSmartPointer< vtkXMLPolyDataWriter > w = vtkSmartPointer< vtkXMLPolyDataWriter >::New();
 		w->SetInputData(m_Surface);
 		w->SetFileName(fn.c_str());

--- a/src/common/itkVTKViewImageAndSegmentation.h
+++ b/src/common/itkVTKViewImageAndSegmentation.h
@@ -16,6 +16,7 @@
 #include "vtkPolyDataMapper.h"
 #include "itkImageToVTKImageFilter.h"
 #include "vtkMassProperties.h"
+#include "itkTriDimensionalMeasurementCalculator.h"
 #include "vtkCutPlaneWidget.h"
 #include <string>
 
@@ -65,9 +66,18 @@ public:
 	};*/
 	void SetSegmentationRenderMode(SegmentationRenderMode);
 
+  // For nodule lengths
+  using NoduleSizerType = itk::TriDimensionalMeasurementCalculator< ImageType >;
+
+  /** Get the sizer from which various nodule lengths can be retrieved */
+  NoduleSizerType *Sizer() { return m_NoduleLengths; }
+
 protected:
   VTKViewImageAndSegmentation();
 	virtual ~VTKViewImageAndSegmentation() override;
+
+  // compute tridimensional lengths
+  void ComputeNoduleLengths();
 
 	using ImageITK2VTKType = itk::ImageToVTKImageFilter< ImageType >;
 	ImageType::Pointer m_Image;
@@ -84,6 +94,8 @@ protected:
 	vtkSmartPointer< vtkActor > m_SurfaceActor;
 	SegmentationRenderMode m_SegmentationRenderMode;
 	double m_Volume;
+
+  typename NoduleSizerType::Pointer m_NoduleLengths;
 
 private:
 };


### PR DESCRIPTION
We add the ability to compute the tri-dimensional measure. This involves 3 linear measures which are all perpendicular to one another. The first measure is RECIST, which is the longest in-plane length of the nodule. The second is another inplane measure which is perpendicular to the RECIST and measures the largest distance between two points on the nodule surface on the same axial plane as RECIST, while peing perpendicular to the RECIST measure. The third is a measure that is perpendicular to both the aforementioned diameters and passes through their intersection point and measures the widest Z span of the nodule.

We also report these numbers. We also report the nodule span along the X,Y and Z axes

![image](https://github.com/accumetra/ACM-LSTK/assets/7565082/7f9d39c6-49c0-4599-9634-d0456fe230c3)
![image](https://github.com/accumetra/ACM-LSTK/assets/7565082/e3244783-4cde-4e1d-9b04-d0132de53979)
